### PR TITLE
Enhance folder scanning to detect newly added images with retry passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,8 +134,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
-credentials.json
-token.json
 
 # Pyre type checker
 .pyre/
@@ -152,3 +150,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Custom Directries and Files
+Computers_Drive
+credentials.json
+token.json


### PR DESCRIPTION
Goal: Ensure that images uploaded after the initial folder scan are also downloaded, even if they arrive with slight delay.

Introduced a multi-pass approach (max_passes with delay_between_passes) in process_folder() to re-scan folders up to 3 times.

Each pass waits 30 seconds (configurable) before checking for new files, increasing reliability for near real-time syncing.

Implemented tracking via already_downloaded set to avoid redundant downloads.

Preserved image deduplication logic and enhanced handling for recent but existing files (checks file age before skipping or deleting).

Applied changes across multiprocessing logic to ensure consistent folder polling in parallel batches.

Minor logging improvements for clearer traceability across passes and batches.